### PR TITLE
Add Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ static/js
 
 # Generated
 *-es5.js*
+
+# Vagrant box
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# Vagrantfile for lib.reviews
+# ===========================
+# This Vagrantfile can spin up a box for lib.reviews development.
+# It won't actually start lib.reviews by itself. To do that,
+# run 'vagrant ssh', then run 'cd /srv/lib.reviews && npm start'.
+#
+Vagrant.configure('2') do |config|
+  config.vm.box = 'debian/jessie64'
+
+  config.vm.post_up_message = <<-END
+    To start lib.reviews, run 'vagrant ssh', then 'cd /srv/lib.reviews && npm start'.
+    lib.reviews will then run on http://localhost:8080 (on the host)."
+  END
+
+  # Make lib.reviews reachable via http://localhost:8080/ on the host.
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  # The debian/jessie64 box doesn't come with Puppet pre-installed,
+  # so we need to run the shell provisioner first.
+  config.vm.provision 'shell', inline: '/usr/bin/apt-get install -y puppet'
+
+  config.vm.provision 'puppet' do |puppet|
+    # Uncomment the line below to make Puppet runs vebrose:
+    # puppet.options = '--verbose --debug'
+  end
+end

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -1,0 +1,135 @@
+# Puppet manifest for setting up lib.reviews on Debian Jessie
+
+# Set $PATH for all Exec resources
+Exec {
+  path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+}
+
+# Make sure apt can fetch packages via https
+package { 'apt-transport-https':
+  ensure => present,
+  before => Exec['apt-get update'],
+}
+
+exec { 'apt-get update':
+  refreshonly => true,
+}
+
+# Increase inotify.max_user_watches. Otherwise pm2 (which watches
+# the filesystem for changes) can crash on an unhandled ENOSPC.
+file { '/etc/sysctl.d/10-fswatch.conf':
+  content => "fs.inotify.max_user_watches = 524288\n",
+  notify  => Exec['update_max_user_watches'],
+}
+
+exec { 'update_max_user_watches':
+  command => 'sysctl --load=/etc/sysctl.d/*.conf',
+  unless  => 'sysctl fs.inotify.max_user_watches | grep -q 524288'
+}
+
+
+#
+# RethinkDB
+#
+
+exec { 'add_rethinkdb_apt_key':
+  command => 'wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | apt-key add -',
+  unless  => 'apt-key list | grep -q RethinkDB',
+  path    => [ '/bin', '/usr/bin' ],
+}
+
+file { '/etc/apt/sources.list.d/rethinkdb.list':
+  ensure  => present,
+  content => "deb https://download.rethinkdb.com/apt ${lsbdistcodename} main\n",
+  require => Exec['add_rethinkdb_apt_key'],
+  notify  => Exec['apt-get update'],
+}
+
+package { 'rethinkdb':
+  ensure  => present,
+  require => Exec['apt-get update'],
+}
+
+file { '/etc/rethinkdb/instances.d/default.conf':
+  source  => 'file:///etc/rethinkdb/default.conf.sample',
+  replace => false,
+  require => Package['rethinkdb'],
+}
+
+service { 'rethinkdb':
+  ensure   => running,
+  enable   => true,
+  provider => 'systemd',
+  require  => File['/etc/rethinkdb/instances.d/default.conf'],
+}
+
+exec { '/etc/init.d/rethinkdb start':
+  unless  => '/etc/init.d/rethinkdb status | grep -q running',
+  require => Service['rethinkdb'],
+}
+
+
+#
+# Node.js
+#
+
+exec { 'add_nodesource_apt_key':
+  command => 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -',
+  unless  => 'apt-key list | grep -q NodeSource',
+}
+
+file { '/etc/apt/sources.list.d/nodesource.list':
+  content => "deb https://deb.nodesource.com/node_6.x ${lsbdistcodename} main\n",
+  require => Exec['add_nodesource_apt_key'],
+  notify  => Exec['apt-get update'],
+}
+
+package { [ 'build-essential', 'git', 'libcap2-bin', 'nodejs' ]:
+  ensure  => present,
+  require => Exec['apt-get update'],
+}
+
+
+# Allow nodejs to bind privileged ports. We wouldn't do this in a production
+# environment, but it's OK for a throwaway VM.
+exec { 'setcap_node':
+  command => 'setcap "cap_net_bind_service=+ep" /usr/bin/nodejs',
+  unless  => 'getcap /usr/bin/nodejs | grep -q cap_net_bind_service',
+  require => Package['libcap2-bin'],
+}
+
+file { '/srv/lib.reviews':
+  ensure => directory,
+  owner  => 'vagrant',
+  group  => 'vagrant',
+  mode   => '0755',
+  before => Exec['git_clone_repo'],
+}
+
+exec { 'git_clone_repo':
+  command => 'git clone https://github.com/eloquence/lib.reviews.git',
+  creates => '/srv/lib.reviews/.git',
+  cwd     => '/srv',
+  user    => 'vagrant',
+}
+
+
+#
+# Application setup
+#
+
+exec { 'npm install':
+  cwd     => '/srv/lib.reviews',
+  creates => '/srv/lib.reviews/node_modules',
+  require => [
+    Package['build-essential', 'nodejs'],
+    Exec['git_clone_repo'],
+  ],
+}
+
+exec { 'grunt':
+  cwd     => '/srv/lib.reviews',
+  command => '/srv/lib.reviews/node_modules/grunt/bin/grunt',
+  creates => '/srv/lib.reviews/static/js',
+  require => Exec['npm install'],
+}


### PR DESCRIPTION
Running 'vagrant up' in the repository root will now provision a Debian
Jessie VM that can run lib.reviews.