### PR TITLE
Improvements to Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,13 +17,19 @@ Vagrant.configure('2') do |config|
   # Make lib.reviews reachable via http://localhost:8080/ on the host.
   config.vm.network :forwarded_port, guest: 80, host: 8080
 
-  config.vm.synced_folder '.', '/vagrant', type: 'nfs'
+  config.vm.synced_folder '.', '/vagrant',
+    :nfs => true,
+    :mount_options => ['noatime', 'nodiratime']
 
   # The debian/jessie64 box doesn't come with Puppet pre-installed,
   # so we need to run the shell provisioner first.
-  config.vm.provision 'shell', inline: '/usr/bin/apt-get install -y puppet'
+  config.vm.provision 'shell', run: 'always', inline: %{
+    DEBIAN_FRONTEND=noninteractive apt-get install -q -y puppet
+    install -o vagrant -g vagrant -d /srv/node_modules
+    mount --bind /srv/node_modules /vagrant/node_modules
+  }
 
-  config.vm.provision 'puppet' do |puppet|
+  config.vm.provision 'puppet', run: 'always' do |puppet|
     # Uncomment the line below to make Puppet runs vebrose:
     # puppet.options = '--verbose --debug'
   end


### PR DESCRIPTION
- Mount a guest-local directory as /vagrant/node_modules. This allows
  the guest to maintain its own set of modules, shadowing those
  installed on the guest (if any).
- Small fixes to resource ordering in Puppet manifest.
- Make the check for missing or incomplete node_modules more robust by
  using 'npm outdated'.