### PR TITLE
IRC bot: automatically regain canonical nickname

### DIFF
--- a/tools/irc-bot.js
+++ b/tools/irc-bot.js
@@ -17,6 +17,17 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const app = express();
 
+bot.once('names', function () {
+  // Every thirty seconds, check that the bot is operating under its canonical
+  // nickname, and attempt to regain it if not. (NickServ's "regain" command
+  // will modify the bot's nickname, if successful.)
+  setInterval(function () {
+    if (bot.nick !== config.botName) {
+      bot.say('NickServ', 'regain ' + config.botName);
+    }
+  }, 30 * 1000);
+});
+
 app.use(bodyParser.json());
 
 app.post('/reviews', function (req, res) {


### PR DESCRIPTION
Make the bot check every thirty seconds that its nickname matches its
configuration. If it does not, attempt to regain the canonical nickname
via "regain".

Note that this is Freenode-specific. It could be made more generic by
replacing the `bot.say(...)` line with `bot.send('NICK', config.botName)`,
but using NickServ is more powerful, because it will force anyone else
who may be holding the nick to release it.