### PR TITLE
added signupLanguage query support for registration

### DIFF
--- a/routes/actions.js
+++ b/routes/actions.js
@@ -213,7 +213,7 @@ router.get('/register', function(req, res) {
 });
 
 router.get('/register/:code', function(req, res, next) {
-  const { code } = req.params.code;
+  const { code } = req.params;
   InviteLink
     .get(code)
     .then(inviteLink => {
@@ -371,14 +371,13 @@ function returnToPath(req, res) {
 // set locale cookie if conditions met, else do nothing
 function setSignupLanguage(req, res) {
     if (req.body.signupLanguage && languages.isValid(req.body.signupLanguage)) {
-    const lang = req.body.signupLanguage;
-    console.log(lang);
-    let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
-    res.cookie('locale', lang, {
-        maxAge,
-        httpOnly: true
-        });
-    i18n.setLocale(req, lang);
+        const lang = req.body.signupLanguage;
+        let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
+        res.cookie('locale', lang, {
+            maxAge,
+            httpOnly: true
+            });
+        i18n.setLocale(req, lang);
     }
 }
 module.exports = router;

--- a/routes/actions.js
+++ b/routes/actions.js
@@ -201,15 +201,7 @@ router.get('/new/user', function(req, res) {
 });
 
 router.get('/register', function(req, res) {
-  if (req.query.signupLanguage && languages.isValid(req.query.signupLanguage)){
-    const lang = req.query.signupLanguage;
-    let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
-    res.cookie('locale', lang, {
-        maxAge,
-        httpOnly: true
-        });
-    i18n.setLocale(req, lang);
-  }
+  setSignupLanguage(req, res);
   if (config.requireInviteLinks)
     return render.template(req, res, 'invite-needed', {
       titleKey: 'register'
@@ -220,15 +212,7 @@ router.get('/register', function(req, res) {
 
 router.get('/register/:code', function(req, res, next) {
   const { code } = req.params.code;
-  if (req.query.signupLanguage && languages.isValid(req.query.signupLanguage)){
-    const lang = req.query.signupLanguage;
-    let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
-    res.cookie('locale', lang, {
-        maxAge,
-        httpOnly: true
-        });
-    i18n.setLocale(req, lang);
-  }
+  setSignupLanguage(req, res);
   InviteLink
     .get(code)
     .then(inviteLink => {
@@ -378,5 +362,18 @@ function returnToPath(req, res) {
   if (typeof returnTo != 'string' || !localPathRegex.test(returnTo))
     returnTo = '/';
   res.redirect(returnTo);
+}
+// check for signupLanguage, ensure valid lang and user not logged in
+// set locale cookie if conditions met, else do nothing
+function setSignupLanguage(req, res) {
+    if (req.query.signupLanguage && languages.isValid(req.query.signupLanguage) && !req.user) {
+    const lang = req.query.signupLanguage;
+    let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
+    res.cookie('locale', lang, {
+        maxAge,
+        httpOnly: true
+        });
+    i18n.setLocale(req, lang);
+    }
 }
 module.exports = router;

--- a/routes/actions.js
+++ b/routes/actions.js
@@ -201,6 +201,15 @@ router.get('/new/user', function(req, res) {
 });
 
 router.get('/register', function(req, res) {
+  if (req.query.signupLanguage && languages.isValid(req.query.signupLanguage)){
+    const lang = req.query.signupLanguage;
+    let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
+    res.cookie('locale', lang, {
+        maxAge,
+        httpOnly: true
+        });
+    i18n.setLocale(req, lang);
+  }
   if (config.requireInviteLinks)
     return render.template(req, res, 'invite-needed', {
       titleKey: 'register'
@@ -210,7 +219,16 @@ router.get('/register', function(req, res) {
 });
 
 router.get('/register/:code', function(req, res, next) {
-  const { code } = req.params;
+  const { code } = req.params.code;
+  if (req.query.signupLanguage && languages.isValid(req.query.signupLanguage)){
+    const lang = req.query.signupLanguage;
+    let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
+    res.cookie('locale', lang, {
+        maxAge,
+        httpOnly: true
+        });
+    i18n.setLocale(req, lang);
+  }
   InviteLink
     .get(code)
     .then(inviteLink => {

--- a/routes/actions.js
+++ b/routes/actions.js
@@ -31,6 +31,9 @@ const formDefs = {
   }, {
     name: 'returnTo',
     required: false
+  }, {
+    name: 'signupLanguage',
+    required: false
   }]
 };
 
@@ -201,7 +204,6 @@ router.get('/new/user', function(req, res) {
 });
 
 router.get('/register', function(req, res) {
-  setSignupLanguage(req, res);
   if (config.requireInviteLinks)
     return render.template(req, res, 'invite-needed', {
       titleKey: 'register'
@@ -212,7 +214,6 @@ router.get('/register', function(req, res) {
 
 router.get('/register/:code', function(req, res, next) {
   const { code } = req.params.code;
-  setSignupLanguage(req, res);
   InviteLink
     .get(code)
     .then(inviteLink => {
@@ -262,6 +263,7 @@ if (!config.requireInviteLinks) {
           if (error) {
             debug.error({ req, error });
           }
+          setSignupLanguage(req, res);
           returnToPath(req, res);
         });
       })
@@ -310,6 +312,7 @@ router.post('/register/:code', function(req, res, next) {
                 if (error) {
                   debug.error({ req, error });
                 }
+                setSignupLanguage(req, res);
                 returnToPath(req, res);
               });
             })
@@ -366,8 +369,9 @@ function returnToPath(req, res) {
 // check for signupLanguage, ensure valid lang and user not logged in
 // set locale cookie if conditions met, else do nothing
 function setSignupLanguage(req, res) {
-    if (req.query.signupLanguage && languages.isValid(req.query.signupLanguage) && !req.user) {
-    const lang = req.query.signupLanguage;
+    if (req.body.signupLanguage && languages.isValid(req.body.signupLanguage)) {
+    const lang = req.body.signupLanguage;
+    console.log(lang);
     let maxAge = 1000 * 60 * config.sessionCookieDuration; // cookie age: 30 days
     res.cookie('locale', lang, {
         maxAge,

--- a/routes/actions.js
+++ b/routes/actions.js
@@ -366,7 +366,8 @@ function returnToPath(req, res) {
     returnTo = '/';
   res.redirect(returnTo);
 }
-// check for signupLanguage, ensure valid lang and user not logged in
+
+// check for signupLanguage, ensure valid lang
 // set locale cookie if conditions met, else do nothing
 function setSignupLanguage(req, res) {
     if (req.body.signupLanguage && languages.isValid(req.body.signupLanguage)) {

--- a/routes/helpers/render.js
+++ b/routes/helpers/render.js
@@ -19,7 +19,8 @@ let render = {
     // override locale cookie using signupLanguage if present
     if (req.query.signupLanguage)
         i18n.setLocale(req, req.query.signupLanguage);
-        
+        vars.signupLanguage = req.query.signupLanguage;
+
     let jsConfig = {
       userName: req.user ? req.user.displayName : undefined,
       userID: req.user ? req.user.id : undefined,

--- a/routes/helpers/render.js
+++ b/routes/helpers/render.js
@@ -3,6 +3,7 @@
 const config = require('config');
 const url = require('url');
 const getJS = require('../../util/get-js');
+const i18n = require('i18n');
 
 // Internal dependencies
 const languages = require('../../locales/languages');
@@ -14,7 +15,11 @@ let render = {
   //  scripts (must not contain sensitive data!)
   template(req, res, view, extraVars, extraJSConfig) {
     let vars = {};
-
+    
+    // override locale cookie using signupLanguage if present
+    if (req.query.signupLanguage)
+        i18n.setLocale(req, req.query.signupLanguage);
+        
     let jsConfig = {
       userName: req.user ? req.user.displayName : undefined,
       userID: req.user ? req.user.id : undefined,

--- a/routes/helpers/render.js
+++ b/routes/helpers/render.js
@@ -15,11 +15,12 @@ let render = {
   //  scripts (must not contain sensitive data!)
   template(req, res, view, extraVars, extraJSConfig) {
     let vars = {};
-    
+
     // override locale cookie using signupLanguage if present
-    if (req.query.signupLanguage)
+    if (req.query.signupLanguage) {
         i18n.setLocale(req, req.query.signupLanguage);
         vars.signupLanguage = req.query.signupLanguage;
+    }
 
     let jsConfig = {
       userName: req.user ? req.user.displayName : undefined,

--- a/views/register.hbs
+++ b/views/register.hbs
@@ -10,6 +10,7 @@
 <form class="pure-form pure-form-aligned" {{#if inviteCode}}action="/register/{{inviteCode}}"{{else}}action="/register"{{/if}} method="post">
 <input type="hidden" value="{{csrfToken}}" name="_csrf">
 <input type="hidden" name="returnTo" value="{{returnTo}}">
+<input type="hidden" name="signupLanguage" value="{{signupLanguage}}">
     <fieldset>
         <div class="pure-control-group">
             <label for="username">{{{__ "username"}}} <span class="required">*</span></label>


### PR DESCRIPTION
added support for signupLanguage for register and register with code routes.  register with code route has not been tested.

Sets locale cookie if signupLanguage query is present and is a valid language, otherwise does nothing.

All tests passing.