### PR TITLE
updated vagrant files to stretch

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,22 +4,24 @@
 # Vagrantfile for lib.reviews
 #
 Vagrant.configure('2') do |config|
-  config.vm.box = 'debian/jessie64'
+  config.vm.box = 'debian/stretch64'
 
   config.vm.post_up_message = <<-END
     To view logs, run 'vagrant ssh', then 'journalctl -u lib-reviews.service'.
     To restart lib-reviews, run 'sudo systemctl restart lib-reviews'.
-    lib.reviews is available at http://localhost:8080 (on the host).
+    lib.reviews is available at http://localhost:8000 (on the host).
   END
 
   config.vm.network :private_network, ip: '10.11.12.13'
 
-  # Make lib.reviews reachable via http://localhost:8080/ on the host.
-  config.vm.network :forwarded_port, guest: 80, host: 8080
+  # Make lib.reviews reachable via http://localhost:8000/ on the host.
+  config.vm.network :forwarded_port, guest: 8000, host: 8000
 
   config.vm.synced_folder '.', '/vagrant',
-    :nfs => true,
-    :mount_options => ['noatime', 'nodiratime']
+    type: 'nfs',
+    nfs_version: 4,
+    nfs_udp: false,
+    linux__nfs_options: ['rw']
 
   # The debian/jessie64 box doesn't come with Puppet pre-installed,
   # so we need to run the shell provisioner first.

--- a/manifests/lib-reviews.service
+++ b/manifests/lib-reviews.service
@@ -8,7 +8,7 @@ Environment="NODE_PATH=/vagrant/node_modules"
 Restart=always
 RestartSec=2s
 WorkingDirectory=/vagrant
-ExecStart=/usr/bin/npm start
+ExecStart=/usr/bin/npm run start-dev
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Updated vm to stretch, updated package location for rethinkdb since there's no package in debian archives, update node to version 8.  Setcap and npm install commands are commented out as they both created issues.  Will need to run npm install on host before starting vm to work in current state.

Confirmed to work on debian testing host.