### PR TITLE
Fix autocomplete row styling regression

### DIFF
--- a/frontend/lib/ac.mjs
+++ b/frontend/lib/ac.mjs
@@ -209,12 +209,15 @@ class Autocomplete {
 
     if (this.selectedIndex >= 0 && this.rows[this.selectedIndex]) {
       const previousRow = this.rows[this.selectedIndex];
+      previousRow.classList.remove('selected');
       this._removeClasses(previousRow, 'SELECTED_ROW');
+      this._addClasses(previousRow, 'ROW');
       previousRow.setAttribute('aria-selected', 'false');
     }
 
     const row = this.rows[nextIndex];
     this._addClasses(row, 'SELECTED_ROW');
+    row.classList.add('selected');
     row.setAttribute('aria-selected', 'true');
     this.selectedIndex = nextIndex;
     this.inputEl.setAttribute('aria-activedescendant', row.id);


### PR DESCRIPTION
## Summary
- restore the base row styling when moving the autocomplete selection
- add the `selected` class so keyboard navigation keeps the highlight visible

Fixes #362 

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3508f0ad4832ba045a404aa10e718