### PR TITLE
tests: bump concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "files": [
       "tests/[0-9]*-*.mjs"
     ],
-    "concurrency": 4,
+    "concurrency": 16,
     "timeout": "2m"
   }
 }


### PR DESCRIPTION
Almost cuts test execution time in half and seems to be reliable in local testing.