### PR TITLE
fix: consistently strip apostrophes in all shapes from slugs

### DIFF
--- a/util/slug.ts
+++ b/util/slug.ts
@@ -42,7 +42,7 @@ export function generateSlugName(str: string): string {
     .trim()
     .toLowerCase()
     .replace(/[&]/g, '-') // Replace ampersands with hyphens
-    .replace(/[?"″'`'<>:]/g, '') // Remove problematic punctuation
+    .replace(/[?"″''`'<>:]/g, '') // Remove problematic punctuation
     .replace(/[ _/]/g, '-') // Replace spaces, underscores, slashes with hyphens
     .replace(/-{2,}/g, '-'); // Collapse multiple hyphens
 


### PR DESCRIPTION
This is more debatable, but since we strip some ' shapes, we should strip them all.