### PR TITLE
exclude more quote-like characters from slugs

### DIFF
--- a/util/slug.ts
+++ b/util/slug.ts
@@ -42,7 +42,7 @@ export function generateSlugName(str: string): string {
     .trim()
     .toLowerCase()
     .replace(/[&]/g, '-') // Replace ampersands with hyphens
-    .replace(/[?"″''`'<>:]/g, '') // Remove problematic punctuation
+    .replace(/[?<>:"″'`‘’‛′“”‹›«»]/g, '') // Remove problematic punctuation
     .replace(/[ _/]/g, '-') // Replace spaces, underscores, slashes with hyphens
     .replace(/-{2,}/g, '-'); // Collapse multiple hyphens
 


### PR DESCRIPTION
This is getting a bit obsessive. :) But hopefully this'll make simple slugs avoid url-encoding a bit more frequently without distracting from the meaning too much.