### PR TITLE
types: Add ManifestTypes bundle for convenience

### DIFF
--- a/dal/README.md
+++ b/dal/README.md
@@ -192,6 +192,9 @@ Manifests drive all type inference:
 - **Convenience helpers** (recommended for manifest files):
   - `ManifestInstance<Manifest, InstanceMethods>` - cleaner than `InferInstance<MergeManifestMethods<...>>`
   - `ManifestModel<Manifest, StaticMethods, InstanceMethods>` - cleaner than `InferConstructor<MergeManifestMethods<...>>`
+- **Bundle helper for manifests**:
+  - `ManifestTypes<Manifest, StaticMethods, InstanceMethods, Relations>` packages the data, virtual, instance, and model types
+    into a single object. Prefer the bundle over repeating individual inferences in each manifest file.
 - Static/instance methods declared via `defineStaticMethods`/`defineInstanceMethods` receive correctly typed `this` via contextual `ThisType`
 
 **Relation Field Typing**: Use the intersection pattern to add strongly-typed relation fields:

--- a/dal/lib/create-model.ts
+++ b/dal/lib/create-model.ts
@@ -424,4 +424,43 @@ export type ManifestModel<
   InstanceMethods extends object = Record<never, InstanceMethod>,
 > = InferConstructor<MergeManifestMethods<Manifest, StaticMethods, InstanceMethods>>;
 
+/**
+ * Bundle of commonly used manifest-derived types.
+ *
+ * This keeps manifest files terse by collecting the different inferred types
+ * in one place, so authors don't have to declare separate aliases for the
+ * base model, base instance, data shape, and virtual fields.
+ */
+export type ManifestTypes<
+  Manifest extends ModelManifest,
+  StaticMethods extends object = EmptyStaticMethods,
+  InstanceMethods extends object = Record<never, InstanceMethod>,
+  RelationFields extends object = Record<never, never>,
+> = {
+  /**
+   * Instance type including any relation fields added via intersection.
+   */
+  Instance: ManifestInstance<Manifest, InstanceMethods> & RelationFields;
+  /**
+   * Model constructor type including additional static/instance methods.
+   */
+  Model: ManifestModel<Manifest, StaticMethods, InstanceMethods>;
+  /**
+   * Base model constructor type without custom statics/instance methods.
+   */
+  BaseModel: InferConstructor<Manifest>;
+  /**
+   * Base instance type without custom instance methods or relations.
+   */
+  BaseInstance: InferInstance<Manifest>;
+  /**
+   * Persisted data shape inferred from the schema.
+   */
+  Data: InferData<Manifest['schema']>;
+  /**
+   * Virtual fields inferred from the schema.
+   */
+  Virtual: ManifestVirtualFields<Manifest>;
+};
+
 export type { ModelConstructorWithStatics, MergeManifestMethods };

--- a/models/manifests/blog-post.ts
+++ b/models/manifests/blog-post.ts
@@ -1,12 +1,7 @@
 import dal from '../../dal/index.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferData,
-  InferInstance,
-  InferVirtual,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 import languages from '../../locales/languages.ts';
 import type { UserAccessContext, UserView } from './user.ts';
 
@@ -44,11 +39,18 @@ const blogPostManifest = {
   },
 } as const satisfies ModelManifest;
 
-type BlogPostInstanceBase = InferInstance<typeof blogPostManifest>;
-type BlogPostModelBase = InferConstructor<typeof blogPostManifest>;
+type BlogPostTypes = ManifestTypes<
+  typeof blogPostManifest,
+  BlogPostStaticMethods,
+  BlogPostInstanceMethods,
+  { creator?: BlogPostCreator }
+>;
 
-export type BlogPostData = InferData<(typeof blogPostManifest)['schema']>;
-export type BlogPostVirtual = InferVirtual<(typeof blogPostManifest)['schema']>;
+type BlogPostInstanceBase = BlogPostTypes['BaseInstance'];
+type BlogPostModelBase = BlogPostTypes['BaseModel'];
+
+export type BlogPostData = BlogPostTypes['Data'];
+export type BlogPostVirtual = BlogPostTypes['Virtual'];
 
 export interface BlogPostInstanceMethods {
   populateUserInfo(
@@ -75,11 +77,8 @@ export interface BlogPostStaticMethods {
 }
 
 // Use intersection pattern for relation types
-export type BlogPostInstance = BlogPostInstanceBase &
-  BlogPostInstanceMethods & {
-    creator?: BlogPostCreator;
-  };
-export type BlogPostModel = BlogPostModelBase & BlogPostStaticMethods;
+export type BlogPostInstance = BlogPostTypes['Instance'];
+export type BlogPostModel = BlogPostTypes['Model'];
 
 /**
  * Create a lazy reference to the BlogPost model for use in other models.

--- a/models/manifests/file.ts
+++ b/models/manifests/file.ts
@@ -1,11 +1,7 @@
 import dal from '../../dal/index.ts';
-import type { ManifestInstance, ManifestModel } from '../../dal/lib/create-model.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 import type { ThingInstance } from './thing.ts';
 import type { UserAccessContext, UserView } from './user.ts';
 
@@ -71,8 +67,17 @@ export interface FileFeedResult<TItem> {
   offsetDate?: Date;
 }
 
-type FileInstanceBase = InferInstance<typeof fileManifest>;
-type FileModelBase = InferConstructor<typeof fileManifest>;
+type FileRelations = { uploader?: UserView; things?: ThingInstance[] };
+
+type FileTypes = ManifestTypes<
+  typeof fileManifest,
+  FileStaticMethods,
+  FileInstanceMethods,
+  FileRelations
+>;
+
+type FileInstanceBase = FileTypes['BaseInstance'];
+type FileModelBase = FileTypes['BaseModel'];
 
 export interface FileInstanceMethods {
   populateUserInfo(
@@ -96,11 +101,8 @@ export interface FileStaticMethods {
 
 // Use intersection pattern for relation types
 // Fields are optional because they're only populated when relations are loaded
-export type FileInstance = ManifestInstance<typeof fileManifest, FileInstanceMethods> & {
-  uploader?: UserView;
-  things?: ThingInstance[];
-};
-export type FileModel = ManifestModel<typeof fileManifest, FileStaticMethods, FileInstanceMethods>;
+export type FileInstance = FileTypes['Instance'];
+export type FileModel = FileTypes['Model'];
 export const fileValidLicenses = validLicenseValues;
 
 /**

--- a/models/manifests/review.ts
+++ b/models/manifests/review.ts
@@ -1,13 +1,8 @@
 import dal from '../../dal/index.ts';
-import type { ManifestInstance, ManifestModel } from '../../dal/lib/create-model.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import type { MultilingualString } from '../../dal/lib/ml-string.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferData,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 import type { InstanceMethod, RevisionActor } from '../../dal/lib/model-types.ts';
 import languages from '../../locales/languages.ts';
 import type { FileInstance } from './file.ts';
@@ -125,9 +120,21 @@ const reviewManifest = {
   ],
 } as const satisfies ModelManifest;
 
-type ReviewInstanceBase = InferInstance<typeof reviewManifest>;
-type ReviewModelBase = InferConstructor<typeof reviewManifest>;
-type ReviewData = InferData<(typeof reviewManifest)['schema']>;
+type ReviewTypes = ManifestTypes<
+  typeof reviewManifest,
+  ReviewStaticMethods,
+  ReviewInstanceMethods,
+  {
+    thing?: ThingInstance;
+    teams?: TeamInstance[];
+    creator?: UserView;
+    socialImage?: FileInstance;
+  }
+>;
+
+type ReviewInstanceBase = ReviewTypes['BaseInstance'];
+type ReviewModelBase = ReviewTypes['BaseModel'];
+type ReviewData = ReviewTypes['Data'];
 
 /**
  * Input for creating a review - combines schema fields with additional create-time data.
@@ -176,18 +183,9 @@ export interface ReviewStaticMethods {
 
 // Use intersection pattern for relation types (avoids circular type errors)
 // Fields are optional because they're only populated when relations are loaded
-export type ReviewInstance = ManifestInstance<typeof reviewManifest, ReviewInstanceMethods> & {
-  thing?: ThingInstance;
-  teams?: TeamInstance[];
-  creator?: UserView;
-  socialImage?: FileInstance;
-};
+export type ReviewInstance = ReviewTypes['Instance'];
 
-export type ReviewModel = ManifestModel<
-  typeof reviewManifest,
-  ReviewStaticMethods,
-  ReviewInstanceMethods
-> & { options: typeof reviewOptions };
+export type ReviewModel = ReviewTypes['Model'] & { options: typeof reviewOptions };
 
 /**
  * Create a typed reference to the Review model for use in cross-model dependencies.

--- a/models/manifests/team-join-request.ts
+++ b/models/manifests/team-join-request.ts
@@ -1,9 +1,6 @@
 import dal from '../../dal/index.ts';
-import type {
-  InferConstructor,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 
 const { types } = dal;
 
@@ -34,7 +31,9 @@ const teamJoinRequestManifest = {
   },
 } as const satisfies ModelManifest;
 
-export type TeamJoinRequestInstance = InferInstance<typeof teamJoinRequestManifest>;
-export type TeamJoinRequestModel = InferConstructor<typeof teamJoinRequestManifest>;
+type TeamJoinRequestTypes = ManifestTypes<typeof teamJoinRequestManifest>;
+
+export type TeamJoinRequestInstance = TeamJoinRequestTypes['Instance'];
+export type TeamJoinRequestModel = TeamJoinRequestTypes['Model'];
 
 export default teamJoinRequestManifest;

--- a/models/manifests/team-slug.ts
+++ b/models/manifests/team-slug.ts
@@ -1,10 +1,7 @@
 import dal from '../../dal/index.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 
 const { types } = dal;
 
@@ -26,24 +23,22 @@ const teamSlugManifest = {
   },
 } as const satisfies ModelManifest;
 
-type TeamSlugInstanceBase = InferInstance<typeof teamSlugManifest>;
-type TeamSlugModelBase = InferConstructor<typeof teamSlugManifest>;
+type TeamSlugTypes = ManifestTypes<
+  typeof teamSlugManifest,
+  TeamSlugStaticMethods,
+  TeamSlugInstanceMethods
+>;
 
 export interface TeamSlugStaticMethods {
-  getByName(
-    this: TeamSlugModelBase & TeamSlugStaticMethods,
-    name: string
-  ): Promise<(TeamSlugInstanceBase & TeamSlugInstanceMethods) | null>;
+  getByName(this: TeamSlugTypes['Model'], name: string): Promise<TeamSlugInstance | null>;
 }
 
 export interface TeamSlugInstanceMethods {
-  qualifiedSave(
-    this: TeamSlugInstanceBase & TeamSlugInstanceMethods
-  ): Promise<TeamSlugInstanceBase & TeamSlugInstanceMethods>;
+  qualifiedSave(this: TeamSlugTypes['Instance']): Promise<TeamSlugInstance>;
 }
 
-export type TeamSlugInstance = TeamSlugInstanceBase & TeamSlugInstanceMethods;
-export type TeamSlugModel = TeamSlugModelBase & TeamSlugStaticMethods;
+export type TeamSlugInstance = TeamSlugTypes['Instance'];
+export type TeamSlugModel = TeamSlugTypes['Model'];
 
 /**
  * Create a lazy reference to the TeamSlug model for use in other models.

--- a/models/manifests/team.ts
+++ b/models/manifests/team.ts
@@ -1,11 +1,7 @@
 import dal from '../../dal/index.ts';
-import type { ManifestInstance, ManifestModel } from '../../dal/lib/create-model.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 import type { ModelInstance } from '../../dal/lib/model-types.ts';
 import languages from '../../locales/languages.ts';
 import type { ReviewInstance } from './review.ts';
@@ -67,7 +63,7 @@ const teamManifest = {
     userCanDelete: types.virtual().default(false),
     // Note: relation fields (members, moderators, joinRequests, reviews) are typed via intersection pattern
     reviewCount: types.virtual<number>().default(undefined),
-    urlID: types.virtual().default(function (this: InferInstance<typeof teamManifest>) {
+    urlID: types.virtual().default(function (this: TeamTypes['BaseInstance']) {
       const slugName =
         typeof this.getValue === 'function'
           ? this.getValue('canonicalSlugName')
@@ -114,8 +110,20 @@ const teamManifest = {
   ],
 } as const satisfies ModelManifest;
 
-type TeamInstanceBase = InferInstance<typeof teamManifest>;
-type TeamModelBase = InferConstructor<typeof teamManifest>;
+type TeamTypes = ManifestTypes<
+  typeof teamManifest,
+  TeamStaticMethods,
+  TeamInstanceMethods,
+  {
+    members?: UserView[];
+    moderators?: UserView[];
+    joinRequests?: TeamJoinRequestInstance[];
+    reviews?: ReviewInstance[];
+  }
+>;
+
+type TeamInstanceBase = TeamTypes['BaseInstance'];
+type TeamModelBase = TeamTypes['BaseModel'];
 
 export interface TeamInstanceMethods {
   populateUserInfo(
@@ -139,13 +147,8 @@ export interface TeamStaticMethods {
 
 // Use intersection pattern for relation types
 // Fields are optional because they're only populated when relations are loaded
-export type TeamInstance = ManifestInstance<typeof teamManifest, TeamInstanceMethods> & {
-  members?: UserView[];
-  moderators?: UserView[];
-  joinRequests?: TeamJoinRequestInstance[];
-  reviews?: ReviewInstance[];
-};
-export type TeamModel = ManifestModel<typeof teamManifest, TeamStaticMethods, TeamInstanceMethods>;
+export type TeamInstance = TeamTypes['Instance'];
+export type TeamModel = TeamTypes['Model'];
 
 /**
  * Create a typed reference to the Team model for use in cross-model dependencies.

--- a/models/manifests/thing-slug.ts
+++ b/models/manifests/thing-slug.ts
@@ -1,10 +1,7 @@
 import dal from '../../dal/index.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 
 const { types } = dal;
 
@@ -47,24 +44,22 @@ const thingSlugManifest = {
   },
 } as const satisfies ModelManifest;
 
-type ThingSlugInstanceBase = InferInstance<typeof thingSlugManifest>;
-type ThingSlugModelBase = InferConstructor<typeof thingSlugManifest>;
+type ThingSlugTypes = ManifestTypes<
+  typeof thingSlugManifest,
+  ThingSlugStaticMethods,
+  ThingSlugInstanceMethods
+>;
 
 export interface ThingSlugStaticMethods {
-  getByName(
-    this: ThingSlugModelBase & ThingSlugStaticMethods,
-    name: string
-  ): Promise<(ThingSlugInstanceBase & ThingSlugInstanceMethods) | null>;
+  getByName(this: ThingSlugTypes['Model'], name: string): Promise<ThingSlugInstance | null>;
 }
 
 export interface ThingSlugInstanceMethods {
-  qualifiedSave(
-    this: ThingSlugInstanceBase & ThingSlugInstanceMethods
-  ): Promise<(ThingSlugInstanceBase & ThingSlugInstanceMethods) | null>;
+  qualifiedSave(this: ThingSlugTypes['Instance']): Promise<ThingSlugInstance | null>;
 }
 
-export type ThingSlugInstance = ThingSlugInstanceBase & ThingSlugInstanceMethods;
-export type ThingSlugModel = ThingSlugModelBase & ThingSlugStaticMethods;
+export type ThingSlugInstance = ThingSlugTypes['Instance'];
+export type ThingSlugModel = ThingSlugTypes['Model'];
 
 /**
  * Create a lazy reference to the ThingSlug model for use in other models.

--- a/models/manifests/user-meta.ts
+++ b/models/manifests/user-meta.ts
@@ -1,11 +1,8 @@
 import dal from '../../dal/index.ts';
+import type { ManifestTypes } from '../../dal/lib/create-model.ts';
 import { ValidationError } from '../../dal/lib/errors.ts';
 import { referenceModel } from '../../dal/lib/model-handle.ts';
-import type {
-  InferConstructor,
-  InferInstance,
-  ModelManifest,
-} from '../../dal/lib/model-manifest.ts';
+import type { ModelManifest } from '../../dal/lib/model-manifest.ts';
 import languages from '../../locales/languages.ts';
 
 const { mlString, types } = dal;
@@ -33,8 +30,10 @@ const userMetaManifest = {
   },
 } as const satisfies ModelManifest;
 
-export type UserMetaInstance = InferInstance<typeof userMetaManifest>;
-export type UserMetaModel = InferConstructor<typeof userMetaManifest>;
+type UserMetaTypes = ManifestTypes<typeof userMetaManifest>;
+
+export type UserMetaInstance = UserMetaTypes['Instance'];
+export type UserMetaModel = UserMetaTypes['Model'];
 
 /**
  * Create a lazy reference to the UserMeta model for use in other models.

--- a/package-lock.json
+++ b/package-lock.json
@@ -396,7 +396,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -420,7 +419,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1750,7 +1748,6 @@
       "integrity": "sha512-LuIQOcb6UmnF7C1PCFmEU1u2hmiHL43fgFQX67sN3H4Z+0Yk0Neo++mFsBjhOAuLzvlQeqAAkeDOZrJs9rzumQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2136,7 +2133,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5321,7 +5317,6 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -5371,8 +5366,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/load-json-file": {
       "version": "7.0.1",
@@ -5438,7 +5432,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -6253,7 +6246,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -6925,7 +6917,6 @@
       "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8035,7 +8026,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -8157,7 +8147,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary
- add a ManifestTypes bundle that model consumers can use to obtain commonly used types
- docs

## Testing
- npm run lint
- npm run typecheck
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69265b2b7e7c832bb700b7479e83307d)