### PR TITLE
feat(email): include more request details in account request mail

### DIFF
--- a/routes/actions.ts
+++ b/routes/actions.ts
@@ -625,7 +625,7 @@ router.post(
 
       const language = req.language || 'en';
 
-      await AccountRequest.createRequest({
+      const createdRequest = await AccountRequest.createRequest({
         plannedReviews: formData.plannedReviews.trim(),
         languages: formData.languages.trim(),
         aboutLinks: formData.aboutLinks.trim(),
@@ -636,7 +636,15 @@ router.post(
       });
       // Moderator notification emails must be in English since we don't store
       // language preferences in the database (only in cookies)
-      sendAccountRequestNotification('en').catch(error => {
+      sendAccountRequestNotification(
+        {
+          email: createdRequest.email,
+          plannedReviews: createdRequest.plannedReviews,
+          languages: createdRequest.languages,
+          aboutLinks: createdRequest.aboutLinks,
+        },
+        'en'
+      ).catch(error => {
         debug.error(`Failed to send account request notification: ${formatMailgunError(error)}`);
       });
 

--- a/views/email/account-request-notification.hbs
+++ b/views/email/account-request-notification.hbs
@@ -3,6 +3,13 @@
   <body>
     <p>{{__ "account request notification greeting"}}</p>
     <p>{{{__ "account request notification intro"}}}</p>
+
+    <h3>Request Details:</h3>
+    <p><strong>Email:</strong> {{requesterEmail}}</p>
+    <p><strong>Languages:</strong><br>{{languages}}</p>
+    <p><strong>Planned Reviews:</strong><br>{{plannedReviews}}</p>
+    <p><strong>About/Links:</strong><br>{{aboutLinks}}</p>
+
     <p>
       {{__ "account request notification instructions"}}<br>
       <a href="{{manageURL}}">{{manageURL}}</a>

--- a/views/email/account-request-notification.txt
+++ b/views/email/account-request-notification.txt
@@ -2,6 +2,19 @@
 
 {{__ "account request notification intro plain"}}
 
+Request Details:
+
+Email: {{requesterEmail}}
+
+Languages:
+{{languages}}
+
+Planned Reviews:
+{{plannedReviews}}
+
+About/Links:
+{{aboutLinks}}
+
 {{__ "account request notification instructions plain"}}
 {{manageURL}}
 


### PR DESCRIPTION
Excerpt only, but this should help quickly spot real requests vs. spam.