### PR TITLE
fix: Retrieve and store Wikidata `mul` labels and desriptions

### DIFF
--- a/adapters/wikidata-backend-adapter.ts
+++ b/adapters/wikidata-backend-adapter.ts
@@ -148,6 +148,8 @@ export default class WikidataBackendAdapter extends AbstractBackendAdapter {
    * not a valid native language.
    */
   getNativeLanguageCode(language: string): string | null {
+    // Wikidata's "mul" is the default label usable in any language; store as undetermined.
+    if (language.toLowerCase() === 'mul') return 'und';
     for (const k in nativeToWikidata) {
       if (nativeToWikidata[k].toUpperCase() === language.toUpperCase()) return k;
     }
@@ -156,7 +158,12 @@ export default class WikidataBackendAdapter extends AbstractBackendAdapter {
 
   /** Return array of the codes we can handle */
   getAcceptedWikidataLanguageCodes(): string[] {
-    return languages.getValidLanguages().map(language => this.getWikidataLanguageCode(language));
+    const supported = languages
+      .getValidLanguages()
+      .map(language => this.getWikidataLanguageCode(language));
+    // Include the Wikidata "mul" label so we can use it as undetermined if no better match exists.
+    supported.push('mul');
+    return supported;
   }
 
   /** Return codes in list format expected by API */

--- a/tests/26-adapter-unit-tests.ts
+++ b/tests/26-adapter-unit-tests.ts
@@ -146,6 +146,19 @@ test('Adapters report correct supported fields', t => {
   t.pass();
 });
 
+test('Wikidata adapter maps mul labels to und and requests mul', t => {
+  const adapter = new WikidataBackendAdapter();
+  const mlString = adapter.convertToMlString({
+    mul: { language: 'mul', value: 'Multilingual default' },
+  });
+
+  t.deepEqual(mlString, { und: 'Multilingual default' });
+  t.true(
+    adapter.getAcceptedWikidataLanguageCodes().includes('mul'),
+    'Adapter should request mul labels'
+  );
+});
+
 test('Adapter throttling serializes requests with configured delays', async t => {
   // Create a fresh OSM adapter instance with throttling enabled
   const osmAdapter = new OpenStreetMapBackendAdapter();


### PR DESCRIPTION
`mul` is used for the "default" for things like movie titles. In lib.reviews, we use `und` when we don't know the language name, so we map it accordingly.